### PR TITLE
Fix JS Date format

### DIFF
--- a/lib/rgviz_rails/executor.rb
+++ b/lib/rgviz_rails/executor.rb
@@ -369,7 +369,7 @@ module Rgviz
         end
         def value.encode_json(*)
           month = strftime("%m").to_i - 1
-          "new Date(#{strftime('%Y,' + month + ',%d')})"
+          "new Date(#{strftime('%Y,' + month.to_s + ',%d')})"
         end
         value
       when :datetime
@@ -379,7 +379,7 @@ module Rgviz
         end
         def value.encode_json(*)
           month = strftime("%m").to_i - 1
-          "new Date(#{strftime('%Y,' + month + ',%d,%H,%M,%S')})"
+          "new Date(#{strftime('%Y,' + month.to_s + ',%d,%H,%M,%S')})"
         end
         value
       when :timeofday


### PR DESCRIPTION
The format was being printed out in y,d,m when it should be y,m,d. Also, JS months are zero indexed :(
