### PR TITLE
fixed the deprecated Model.all(params) for rails 4.1

### DIFF
--- a/lib/rgviz_rails/executor.rb
+++ b/lib/rgviz_rails/executor.rb
@@ -185,7 +185,8 @@ module Rgviz
         end
       end
 
-      results = @model_class.send :all,
+      results = @model_class.send :find,
+        :all,
         :select => @selects.join(','),
         :conditions => conditions,
         :group => @group,


### PR DESCRIPTION
In Rails 4.0 Model.all(params) allowed extra params which is
used by rgviz-rails to query the model. In Rails 4.1
Model.all(params) with params was deprecated, and only Model.all
is acceptable. It turns out Model.all(params) was an alias
for Model.find(:all, params). This fixes the Exception raised for
sending an argument, where none is expected.