### PR TITLE
Update plain text rendering

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gemspec
 group :development, :test do
   gem "rake"
   gem "sqlite3"
-  gem "machinist", "1.0.6"
+  gem "machinist"
   gem "faker"
   gem "rspec"
 end

--- a/lib/rgviz_rails.rb
+++ b/lib/rgviz_rails.rb
@@ -11,7 +11,7 @@ module RgvizRails
     end
     def date.encode_json(*)
       month = strftime("%m").to_i - 1
-      "new Date(#{strftime("%Y,#{month},%d")})"
+      "Date(#{strftime("%Y,#{month},%d")})"
     end
     date
   end
@@ -22,7 +22,7 @@ module RgvizRails
     end
     def time.encode_json(*)
       month = strftime("%m").to_i - 1
-      "new Date(#{strftime("%Y,#{month},%d,%H,%M,%S")})"
+      "Date(#{strftime("%Y,#{month},%d,%H,%M,%S")})"
     end
     time
   end
@@ -32,7 +32,7 @@ module RgvizRails
       self
     end
     def time.encode_json(*)
-      "new Date(#{strftime('0,0,0,%H,%M,%S')})"
+      "Date(#{strftime('0,0,0,%H,%M,%S')})"
     end
     time
   end

--- a/lib/rgviz_rails/executor.rb
+++ b/lib/rgviz_rails/executor.rb
@@ -185,14 +185,14 @@ module Rgviz
         end
       end
 
-      results = @model_class.send :all,
-        :select => @selects.join(','),
-        :conditions => conditions,
-        :group => @group,
-        :order => @order,
-        :limit => @query.limit,
-        :offset => @query.offset,
-        :joins => @joins
+      results = @model_class
+        .select(@selects.join(','))
+        .where(conditions)
+        .group(@group)
+        .order(@order)
+        .limit(@query.limit)
+        .offset(@query.offset)
+        .left_joins(@joins)
 
       if @pivots.empty? || results.empty?
         @table.cols = @table.cols[0 ... @max_before_pivot_columns] if @pivots.present?
@@ -381,13 +381,14 @@ module Rgviz
       when :boolean
         value == 1 || value == '1' ? true : false
       when :date
-        value = Time.parse(value).to_date if value.is_a? String
+        value = Time.zone.parse(value).to_date if value.is_a? String
         RgvizRails::date(value)
       when :datetime
-        value = Time.parse(value) if value.is_a? String
+        value = Time.zone.parse(value) if value.is_a? String
         RgvizRails::datetime(value)
       when :timeofday
-        value = Time.parse(value) if value.is_a? String
+        value = Time.zone.parse(value) if value.is_a? String
+        puts RgvizRails::time_of_day(value)
         RgvizRails::time_of_day(value)
       else
         value.to_s

--- a/lib/rgviz_rails/init.rb
+++ b/lib/rgviz_rails/init.rb
@@ -38,29 +38,29 @@ module Rgviz
 
               case tqx['out']
               when 'json'
-                render_without_rgviz :text => Rgviz::JsRenderer.render(table, tqx)
+                render_without_rgviz plain: Rgviz::JsRenderer.render(table, tqx)
               when 'html'
-                render_without_rgviz :text => Rgviz::HtmlRenderer.render(table)
+                render_without_rgviz plain: Rgviz::HtmlRenderer.render(table)
               when 'csv'
                 csv_output = Rgviz::CsvRenderer.render(table)
                 if tqx['outFileName']
                   send_data csv_output, :filename => tqx['outFileName'], :type => 'text/csv'
                 else
-                  render_without_rgviz :text => csv_output
+                  render_without_rgviz plain: csv_output
                 end
               else
-                render_without_rgviz :text => Rgviz::JsRenderer.render_error('not_supported', "Unsupported output type: #{out}", tqx)
+                render_without_rgviz plain: Rgviz::JsRenderer.render_error('not_supported', "Unsupported output type: #{out}", tqx)
               end
             rescue Exception => e
               case tqx['out']
               when 'json'
-                render_without_rgviz :text => Rgviz::JsRenderer.render_error('invalid_query', e.message, tqx)
+                render_without_rgviz plain: Rgviz::JsRenderer.render_error('invalid_query', e.message, tqx)
               when 'html'
-                render_without_rgviz :text => "<b>Error:</b> #{e.message}"
+                render_without_rgviz plain: "<b>Error:</b> #{e.message}"
               when 'csv'
-                render_without_rgviz :text => "Error: #{e.message}"
+                render_without_rgviz plain: "Error: #{e.message}"
               else
-                render_without_rgviz :text => "<b>Unsupported output type:</b> #{out}"
+                render_without_rgviz plain: "<b>Unsupported output type:</b> #{out}"
               end
             end
           end

--- a/lib/rgviz_rails/init.rb
+++ b/lib/rgviz_rails/init.rb
@@ -68,7 +68,8 @@ module Rgviz
           render_without_rgviz *args, &block
         end
       end
-      alias_method_chain :render, :rgviz
+       alias_method :render_without_rgviz, :render
+       alias_method :render, :render_with_rgviz
     end
   end
 end

--- a/rgviz-rails.gemspec
+++ b/rgviz-rails.gemspec
@@ -1,32 +1,32 @@
 # -*- encoding: utf-8 -*-
-$:.push File.expand_path("../lib", __FILE__)
+# stub: rgviz-rails 1.0.0 ruby lib
 
-require "rgviz_rails/version"
+Gem::Specification.new do |s|
+  s.name = "rgviz-rails".freeze
+  s.version = "2.0.0"
 
-spec = Gem::Specification.new do |s|
-  s.name = "rgviz-rails"
-  s.version = RgvizRails::VERSION
-  s.author = "Ary Borenszweig"
-  s.email = "aborenszweig@manas.com.ar"
-  s.homepage = "http://github.com/asterite/rgviz-rails"
-  s.platform = Gem::Platform::RUBY
-  s.summary = "rgviz for rails"
-  s.files = [
-    "lib/rgviz_rails.rb",
-    "lib/rgviz_rails/executor.rb",
-    "lib/rgviz_rails/js_renderer.rb",
-    "lib/rgviz_rails/parser.rb",
-    "lib/rgviz_rails/tqx.rb",
-    "lib/rgviz_rails/view_helper.rb",
-    "lib/rgviz_rails/adapters/mysql_adapter.rb",
-    "lib/rgviz_rails/adapters/postgresql_adapter.rb",
-    "lib/rgviz_rails/adapters/sqlite_adapter.rb",
-    "lib/rgviz_rails/init.rb",
-    "rails/init.rb"
-  ]
-  s.add_dependency "rgviz", ">=0.50"
-  s.add_dependency "rails"
-  s.require_path = "lib"
-  s.has_rdoc = false
-  s.extra_rdoc_files = ["README.markdown"]
+  s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
+  s.require_paths = ["lib".freeze]
+  s.authors = ["Ary Borenszweig".freeze]
+  s.date = "2023-02-06"
+  s.email = "aborenszweig@manas.com.ar".freeze
+  s.extra_rdoc_files = ["README.markdown".freeze]
+  s.files = ["README.markdown".freeze, "lib/rgviz_rails.rb".freeze, "lib/rgviz_rails/adapters/mysql_adapter.rb".freeze, "lib/rgviz_rails/adapters/postgresql_adapter.rb".freeze, "lib/rgviz_rails/adapters/sqlite_adapter.rb".freeze, "lib/rgviz_rails/executor.rb".freeze, "lib/rgviz_rails/init.rb".freeze, "lib/rgviz_rails/js_renderer.rb".freeze, "lib/rgviz_rails/parser.rb".freeze, "lib/rgviz_rails/tqx.rb".freeze, "lib/rgviz_rails/view_helper.rb".freeze, "rails/init.rb".freeze]
+  s.homepage = "http://github.com/asterite/rgviz-rails".freeze
+  s.rubygems_version = "3.3.26".freeze
+  s.summary = "rgviz for rails".freeze
+
+  s.installed_by_version = "3.3.26" if s.respond_to? :installed_by_version
+
+  if s.respond_to? :specification_version then
+    s.specification_version = 4
+  end
+
+  if s.respond_to? :add_runtime_dependency then
+    s.add_runtime_dependency(%q<rgviz>.freeze, [">= 0.50"])
+    s.add_runtime_dependency(%q<rails>.freeze, [">= 0"])
+  else
+    s.add_dependency(%q<rgviz>.freeze, [">= 0.50"])
+    s.add_dependency(%q<rails>.freeze, [">= 0"])
+  end
 end

--- a/spec/blueprints.rb
+++ b/spec/blueprints.rb
@@ -1,25 +1,22 @@
 require 'machinist/active_record'
-require 'sham'
 require 'faker'
 
-Sham.define do
-  name { Faker::Name.name }
-  number(:unique => false) { rand(100) + 1 }
-  date { Date.parse("#{rand(40) + 1970}-#{rand(12) + 1}-#{rand(28) + 1}") }
-end
+name  = Faker::Name.name
+number = rand(100) + 1
+date =  Date.parse("#{rand(40) + 1970}-#{rand(12) + 1}-#{rand(28) + 1}")
 
 City.blueprint do
-  name
+  name {name}
   country
 end
 
 Country.blueprint do
-  name
+  name {name}
 end
 
 Person.blueprint do
-  name
-  age { Sham::number }
-  birthday { Sham::date }
+  name {name}
+  age {number}
+  birthday {date}
   city
 end

--- a/spec/rgviz_rails/executor_spec.rb
+++ b/spec/rgviz_rails/executor_spec.rb
@@ -27,573 +27,573 @@ describe Executor do
       if block_given?
         yield
       else
-        Person.make
+        Person.make!
       end
 
       table = exec "select #{query}", options
-      table.cols.length.should == 1
 
-      table.cols[0].id.should == id
-      table.cols[0].type.should == type
-      table.cols[0].label.should == label
+      expect(table.cols.length).to eq(1)
 
-      table.rows.length.should == 1
-      table.rows[0].c.length.should == 1
+      expect(table.cols[0].id).to eq(id)
+      expect(table.cols[0].type).to eq(type)
+      expect(table.cols[0].label).to eq(label)
 
-      table.rows[0].c[0].v.should == value
-      table.rows[0].c[0].f.should == format
+      expect(table.rows.length).to eq(1)
+      expect(table.rows[0].c.length).to eq(1)
+      expect(table.rows[0].c[0].v).to eq(value)
+      expect(table.rows[0].c[0].f).to eq(format)
     end
   end
 
   it "processes select *" do
-    p = Person.make
+      p = Person.make!
+      table = exec 'select *'
+      expect(table.cols.length).to eq(7)
 
-    table = exec 'select *'
-    table.cols.length.should == 7
-
-    i = 0
-    [['id', :number], ['name', :string], ['age', :number], ['birthday', :date],
+      i = 0
+      [['id', :number], ['name', :string], ['age', :number], ['birthday', :date],
       ['created_at', :datetime], ['updated_at', :datetime],
       ['city_id', :number]].each do |id, type|
-      table.cols[i].id.should == id
-      table.cols[i].type.should == type
-      table.cols[i].label.should == id
-      i += 1
-    end
-
-    table.rows.length.should == 1
-    table.rows[0].c.length.should == 7
-
-    i = 0
-    [p.id, p.name, p.age, p.birthday,
-      p.created_at, p.updated_at, p.city.id].each do |val|
-      table.rows[0].c[i].v.should == val
-      i += 1
-    end
-  end
-
-  it_processes_single_select_column 'name', 'name', :string, 'foo', 'name' do
-    Person.make :name => 'foo'
-  end
-
-  it_processes_single_select_column '1', 'c0', :number, 1, '1'
-  it_processes_single_select_column '1.2', 'c0', :number, 1.2, '1.2'
-  it_processes_single_select_column '"hello"', 'c0', :string, 'hello', "'hello'"
-  it_processes_single_select_column 'false', 'c0', :boolean, false, 'false'
-  it_processes_single_select_column 'true', 'c0', :boolean, true, 'true'
-  it_processes_single_select_column 'date "2010-01-02"', 'c0', :date, Time.parse('2010-01-02').to_date, "date '2010-01-02'"
-  it_processes_single_select_column 'datetime "2010-01-02 10:11:12"', 'c0', :datetime, Time.parse('2010-01-02 10:11:12'), "datetime '2010-01-02 10:11:12'"
-  it_processes_single_select_column 'timeofday "10:11:12"', 'c0', :timeofday, Time.parse('10:11:12'), "timeofday '10:11:12'"
-
-  it_processes_single_select_column '1 + 2', 'c0', :number, 3, '1 + 2'
-  it_processes_single_select_column '3 - 2', 'c0', :number, 1, '3 - 2'
-  it_processes_single_select_column '2 * 3', 'c0', :number, 6, '2 * 3'
-  it_processes_single_select_column '6 / 3', 'c0', :number, 2, '6 / 3'
-  it_processes_single_select_column '3 * age', 'c0', :number, 60, '3 * age' do
-    Person.make :age => 20
-  end
-
-  it_processes_single_select_column 'sum(age)', 'c0', :number, 6, 'sum(age)' do
-    [1, 2, 3].each{|i| Person.make :age => i}
-  end
-
-  it_processes_single_select_column 'avg(age)', 'c0', :number, 30, 'avg(age)' do
-    [10, 20, 60].each{|i| Person.make :age => i}
-  end
-
-  it_processes_single_select_column 'count(age)', 'c0', :number, 3, 'count(age)' do
-    3.times{|i| Person.make}
-  end
-
-  it_processes_single_select_column 'max(age)', 'c0', :number, 3, 'max(age)' do
-    [1, 2, 3].each{|i| Person.make :age => i}
-  end
-
-  it_processes_single_select_column 'min(age)', 'c0', :number, 1, 'min(age)' do
-    [1, 2, 3].each{|i| Person.make :age => i}
-  end
-
-  it_processes_single_select_column 'age where age > 2', 'age', :number, 3, 'age' do
-    [1, 2, 3].each{|i| Person.make :age => i}
-  end
-
-  it_processes_single_select_column 'age where age > 2 and age <= 3', 'age', :number, 3, 'age' do
-    [1, 2, 3, 4, 5].each{|i| Person.make :age => i}
-  end
-
-  it_processes_single_select_column 'name where age is null', 'name', :string, 'b', 'name' do
-    Person.make :age => 1, :name => 'a'
-    Person.make :age => nil, :name => 'b'
-  end
-
-  it_processes_single_select_column "age where city_name = 'Laos' and year(birthday) = '2010'", 'age', :number, 1, 'age' do
-    Person.make :age => 1, :name => 'a', :city => City.make(:name => 'Laos'), :birthday => '2010-01-01'
-  end
-
-  it_processes_single_select_column 'name where age is not null', 'name', :string, 'a', 'name' do
-    Person.make :age => 1, :name => 'a'
-    Person.make :age => nil, :name => 'b'
-  end
-
-  it_processes_single_select_column 'virtual_column', 'virtual_column', :number, 2, 'virtual_column', nil, :virtual_columns => {'virtual_column' => {:sql => 'case 1 when 1 then 2 else 3 end', :type => :number}}
-  it_processes_single_select_column 'virtual_column', 'virtual_column', :number, 3, 'virtual_column', nil, :virtual_columns => {'virtual_column' => {:gql => '1 + 2'}}
-  it_processes_single_select_column 'virtual_column', 'virtual_column', :number, 3, 'virtual_column', nil, :virtual_columns => {'virtual_column' => '1 + 2'}
-
-  it "processes group by" do
-    Person.make :name => 'one', :age => 1
-    Person.make :name => 'one', :age => 2
-    Person.make :name => 'two', :age => 3
-    Person.make :name => 'two', :age => 4
-
-    table = exec 'select max(age) group by name order by name'
-
-    table.rows.length.should == 2
-    table.rows[0].c.length.should == 1
-    table.rows[0].c[0].v.should == 2
-    table.rows[1].c.length.should == 1
-    table.rows[1].c[0].v.should == 4
-  end
-
-  it "processes order by" do
-    Person.make :age => 1
-    Person.make :age => 3
-    Person.make :age => 2
-
-    table = exec 'select age order by age desc'
-
-    table.rows.length.should == 3
-    table.rows[0].c.length.should == 1
-    table.rows[0].c[0].v.should == 3
-    table.rows[1].c.length.should == 1
-    table.rows[1].c[0].v.should == 2
-    table.rows[2].c.length.should == 1
-    table.rows[2].c[0].v.should == 1
-  end
-
-  it_processes_single_select_column 'age where age > 3 order by age limit 1', 'age', :number, 4, 'age' do
-    [1, 2, 3, 4, 5].each{|i| Person.make :age => i}
-  end
-
-  it_processes_single_select_column 'age where age > 3 order by age limit 1 offset 1', 'age', :number, 5, 'age' do
-    [1, 2, 3, 4, 5].each{|i| Person.make :age => i}
-  end
-
-  it_processes_single_select_column 'city_name', 'city_name', :string, 'Buenos Aires', 'city_name' do
-    Person.make :city => City.make(:name => 'Buenos Aires')
-  end
-
-  it_processes_single_select_column 'city_country_name', 'city_country_name', :string, 'Argentina', 'city_country_name' do
-    Person.make :city => City.make(:country => Country.make(:name => 'Argentina'))
-  end
-
-  it_processes_single_select_column 'city_country_name group by city_country_name', 'city_country_name', :string, 'Argentina', 'city_country_name' do
-    Person.make :city => City.make(:country => Country.make(:name => 'Argentina'))
-  end
-
-  it "processes with conditions as string" do
-    Person.make :age => 1
-    Person.make :age => 2
-    Person.make :age => 3
-
-    table = exec 'select age', :conditions => 'age = 2'
-
-    table.rows.length.should == 1
-    table.rows[0].c.length.should == 1
-    table.rows[0].c[0].v.should == 2
-  end
-
-  it "processes with conditions as string and another filter" do
-    Person.make :age => 1
-    Person.make :age => 2
-    Person.make :age => 3
-
-    table = exec 'select age where age > 1', :conditions => 'age < 3'
-
-    table.rows.length.should == 1
-    table.rows[0].c.length.should == 1
-    table.rows[0].c[0].v.should == 2
-  end
-
-  it "processes with conditions as array" do
-    Person.make :age => 1
-    Person.make :age => 2
-    Person.make :age => 3
-
-    table = exec 'select age', :conditions => ['age = ?', 2]
-
-    table.rows.length.should == 1
-    table.rows[0].c.length.should == 1
-    table.rows[0].c[0].v.should == 2
-  end
-
-  it "processes with conditions as array and another filter" do
-    Person.make :age => 1
-    Person.make :age => 2
-    Person.make :age => 3
-
-    table = exec 'select age where age > 1', :conditions => ['age < ?', 3]
-
-    table.rows.length.should == 1
-    table.rows[0].c.length.should == 1
-    table.rows[0].c[0].v.should == 2
-  end
-
-  it "processes with conditions as empty array and another filter" do
-    Person.make :age => 1
-    Person.make :age => 2
-    Person.make :age => 3
-
-    table = exec 'select age where age > 2', :conditions => []
-
-    table.rows.length.should == 1
-    table.rows[0].c.length.should == 1
-    table.rows[0].c[0].v.should == 3
-  end
-
-  [['year', 2006], ['month', 5], ['day', 2],
-   ['hour', 3], ['minute', 4], ['second', 9],
-   ['dayOfWeek', 3]].each do |str, val|
-    it_processes_single_select_column "#{str}(created_at)", 'c0', :number, val, "#{str}(created_at)" do
-      Person.make :created_at => Time.parse('2006-05-02 3:04:09')
-    end
-  end
-
-#  it_processes_single_select_column "quarter(created_at)", 'c0', :number, 2, 'quarter(created_at)' do
-#    Person.make :created_at => Time.parse('2006-05-02 3:04:09')
-#  end
-
-  it_processes_single_select_column "dateDiff(date '2008-03-13', date '2008-03-10')", 'c0', :number, 3, "dateDiff(date '2008-03-13', date '2008-03-10')"
-
-#  it_processes_single_select_column "now()", 'c0', :datetime, Time.now.utc.strftime("%Y-%m-%d %H:%M:%S"), "now()" do
-#    Person.make :created_at => Time.parse('2006-05-02 3:04:09')
-#  end
-
-  it_processes_single_select_column "toDate('2008-03-13')", 'c0', :date, Time.parse("2008-03-13").to_date, "toDate('2008-03-13')"
-
-  it_processes_single_select_column "toDate(created_at)", 'c0', :date, Time.parse("2008-03-13").to_date, "toDate(created_at)" do
-    Person.make :created_at => Time.parse('2008-03-13 3:04:09')
-  end
-
-#  it_processes_single_select_column "toDate(1234567890000)", 'c0', :date, Date.parse('2009-02-13').to_s, "toDate(1234567890000)"
-
-  it_processes_single_select_column "upper(name)", 'c0', :string, 'FOO', "upper(name)" do
-    Person.make :name => 'foo'
-  end
-
-  it_processes_single_select_column "lower(name)", 'c0', :string, 'foo', "lower(name)" do
-    Person.make :name => 'FOO'
-  end
-
-  it_processes_single_select_column "concat(age)", 'c0', :string, '20', "concat(age)" do
-    Person.make :age => 20
-  end
-
-  it_processes_single_select_column "concat(name, 'bar')", 'c0', :string, 'foobar', "concat(name, 'bar')" do
-    Person.make :name => 'foo'
-  end
-
-  it_processes_single_select_column 'round(1.2)', 'c0', :number, 1, 'round(1.2)', nil, :extensions => true
-
-  it_processes_single_select_column 'floor(1.2)', 'c0', :number, 1, 'floor(1.2)', nil, :extensions => true
-
-  it_processes_single_select_column "name label name 'my name'", 'name', :string, 'foo', "my name" do
-    Person.make :name => 'foo'
-  end
-
-  it_processes_single_select_column "1 + 2 label 1 + 2 'my name'", 'c0', :number, 3, "my name"
-
-  it_processes_single_select_column "sum(age) label sum(age) 'my name'", 'c0', :number, 2, "my name" do
-    Person.make :age => 2
-  end
-
-  it_processes_single_select_column "1 options no_values", 'c0', :number, nil, "1"
-
-  it_processes_single_select_column '1 where foo_bars_id != 0', 'c0', :number, 1, '1', nil, :model => Foo do
-    foo = Foo.create!
-    FooBar.create! :foo_id => foo.id
-  end
-
-  it "processes pivot" do
-    Person.make :name => 'Eng', :birthday => '2000-01-12', :age => 1000
-    Person.make :name => 'Eng', :birthday => '2000-01-12', :age => 500
-    Person.make :name => 'Eng', :birthday => '2000-01-13', :age => 600
-    Person.make :name => 'Sales', :birthday => '2000-01-12', :age => 400
-    Person.make :name => 'Sales', :birthday => '2000-01-12', :age => 350
-    Person.make :name => 'Marketing', :birthday => '2000-01-13', :age => 800
-
-    table = exec 'select name, sum(age) group by name pivot birthday order by name'
-
-    table.cols.length.should == 3
-
-    i = 0
-    [['c0', :string, 'name'],
-     ['c1', :number, '2000-01-12 sum(age)'],
-     ['c2', :number, '2000-01-13 sum(age)']].each do |id, type, label|
-      table.cols[i].id.should == id
-      table.cols[i].type.should == type
-      table.cols[i].label.should == label
-      i += 1
-    end
-
-    table.rows.length.should == 3
-
-    i = 0
-    [['Eng', 1500, 600],
-     ['Marketing', nil, 800],
-     ['Sales', 750, nil]].each do |values|
-      table.rows[i].c.length.should == 3
-      values.each_with_index do |v, j|
-        table.rows[i].c[j].v.should == v
+        expect(table.cols[i].id).to eq(id)
+        expect(table.cols[i].type).to eq(type)
+        expect(table.cols[i].label).to eq(id)
+        i += 1
       end
-      i += 1
-    end
-  end
 
-  it "processes pivot2" do
-    Person.make :name => 'Eng', :birthday => '2000-01-12', :age => 1000
-    Person.make :name => 'Eng', :birthday => '2000-01-12', :age => 500
-    Person.make :name => 'Eng', :birthday => '2000-01-13', :age => 600
-    Person.make :name => 'Sales', :birthday => '2000-01-12', :age => 400
-    Person.make :name => 'Sales', :birthday => '2000-01-12', :age => 350
-    Person.make :name => 'Marketing', :birthday => '2000-01-13', :age => 800
+      expect(table.rows.length).to eq(1)
+      expect(table.rows[0].c.length).to eq(7)
 
-    table = exec 'select sum(age), name group by name pivot birthday order by name'
+      i = 0
 
-    table.cols.length.should == 3
-
-    i = 0
-    [['c0', :number, '2000-01-12 sum(age)'],
-     ['c1', :number, '2000-01-13 sum(age)'],
-     ['c2', :string, 'name']].each do |id, type, label|
-      table.cols[i].id.should == id
-      table.cols[i].type.should == type
-      table.cols[i].label.should == label
-      i += 1
+      [p.id, p.name, p.age, p.birthday,
+        p.created_at, p.updated_at, p.city.id].each do |val|
+          expect(table.rows[0].c[i].v).to eq(val)
+          i += 1
+        end
     end
 
-    table.rows.length.should == 3
+    it_processes_single_select_column 'name', 'name', :string, 'foo', 'name' do
+      Person.make! :name => 'foo'
+    end
 
-    i = 0
-    [[1500, 600, 'Eng'],
-     [nil, 800, 'Marketing'],
-     [750, nil, 'Sales']].each do |values|
-      table.rows[i].c.length.should == 3
-      values.each_with_index do |v, j|
-        table.rows[i].c[j].v.should == v
+    it_processes_single_select_column '1', 'c0', :number, 1, '1'
+    it_processes_single_select_column '1.2', 'c0', :number, 1.2, '1.2'
+    it_processes_single_select_column '"hello"', 'c0', :string, 'hello', "'hello'"
+    it_processes_single_select_column 'false', 'c0', :boolean, false, 'false'
+    it_processes_single_select_column 'true', 'c0', :boolean, true, 'true'
+    it_processes_single_select_column 'date "2010-01-02"', 'c0', :date, Time.parse('2010-01-02').to_date, "date '2010-01-02'"
+    it_processes_single_select_column 'datetime "2010-01-02 10:11:12"', 'c0', :datetime, Time.parse('2010-01-02 10:11:12'), "datetime '2010-01-02 10:11:12'"
+    it_processes_single_select_column 'timeofday "10:11:12"', 'c0', :timeofday, Time.parse('10:11:12'), "timeofday '10:11:12'"
+
+    it_processes_single_select_column '1 + 2', 'c0', :number, 3, '1 + 2'
+    it_processes_single_select_column '3 - 2', 'c0', :number, 1, '3 - 2'
+    it_processes_single_select_column '2 * 3', 'c0', :number, 6, '2 * 3'
+    it_processes_single_select_column '6 / 3', 'c0', :number, 2, '6 / 3'
+    it_processes_single_select_column '3 * age', 'c0', :number, 60, '3 * age' do
+      Person.make! :age => 20
+    end
+
+    it_processes_single_select_column 'sum(age)', 'c0', :number, 6, 'sum(age)' do
+      [1, 2, 3].each{|i| Person.make! :age => i}
+    end
+
+    it_processes_single_select_column 'avg(age)', 'c0', :number, 30, 'avg(age)' do
+      [10, 20, 60].each{|i| Person.make! :age => i}
+    end
+
+    it_processes_single_select_column 'count(age)', 'c0', :number, 3, 'count(age)' do
+      3.times{|i| Person.make!}
+    end
+
+    it_processes_single_select_column 'max(age)', 'c0', :number, 3, 'max(age)' do
+      [1, 2, 3].each{|i| Person.make! :age => i}
+    end
+
+    it_processes_single_select_column 'min(age)', 'c0', :number, 1, 'min(age)' do
+      [1, 2, 3].each{|i| Person.make! :age => i}
+    end
+
+    it_processes_single_select_column 'age where age > 2', 'age', :number, 3, 'age' do
+      [1, 2, 3].each{|i| Person.make! :age => i}
+    end
+
+    it_processes_single_select_column 'age where age > 2 and age <= 3', 'age', :number, 3, 'age' do
+      [1, 2, 3, 4, 5].each{|i| Person.make! :age => i}
+    end
+
+    it_processes_single_select_column 'name where age is null', 'name', :string, 'b', 'name' do
+      Person.make! :age => 1, :name => 'a'
+      Person.make! :age => nil, :name => 'b'
+    end
+
+    it_processes_single_select_column "age where city_name = 'Laos' and year(birthday) = '2010'", 'age', :number, 1, 'age' do
+      Person.make! :age => 1, :name => 'a', :city => City.make!(:name => 'Laos'), :birthday => '2010-01-01'
+    end
+
+    it_processes_single_select_column 'name where age is not null', 'name', :string, 'a', 'name' do
+      Person.make! :age => 1, :name => 'a'
+      Person.make! :age => nil, :name => 'b'
+    end
+
+    it_processes_single_select_column 'virtual_column', 'virtual_column', :number, 2, 'virtual_column', nil, :virtual_columns => {'virtual_column' => {:sql => 'case 1 when 1 then 2 else 3 end', :type => :number}}
+    it_processes_single_select_column 'virtual_column', 'virtual_column', :number, 3, 'virtual_column', nil, :virtual_columns => {'virtual_column' => {:gql => '1 + 2'}}
+    it_processes_single_select_column 'virtual_column', 'virtual_column', :number, 3, 'virtual_column', nil, :virtual_columns => {'virtual_column' => '1 + 2'}
+
+    it "processes group by" do
+      Person.make! :name => 'one', :age => 1
+      Person.make! :name => 'one', :age => 2
+      Person.make! :name => 'two', :age => 3
+      Person.make! :name => 'two', :age => 4
+
+      table = exec 'select max(age) group by name order by name'
+
+      expect(table.rows.length).to eq(2)
+      expect(table.rows[0].c.length).to eq(1)
+      expect(table.rows[0].c[0].v).to eq(2)
+      expect(table.rows[1].c.length).to eq(1)
+      expect(table.rows[1].c[0].v).to eq(4)
+    end
+
+    it "processes order by" do
+      Person.make! :age => 1
+      Person.make! :age => 3
+      Person.make! :age => 2
+
+      table = exec 'select age order by age desc'
+
+      expect(table.rows.length).to eq(3)
+      expect(table.rows[0].c.length).to eq(1)
+      expect(table.rows[0].c[0].v).to eq(3)
+      expect(table.rows[1].c.length).to eq(1)
+      expect(table.rows[1].c[0].v).to eq(2)
+      expect(table.rows[2].c.length).to eq(1)
+      expect(table.rows[2].c[0].v).to eq(1)
+    end
+
+    it_processes_single_select_column 'age where age > 3 order by age limit 1', 'age', :number, 4, 'age' do
+      [1, 2, 3, 4, 5].each{|i| Person.make! :age => i}
+    end
+
+    it_processes_single_select_column 'age where age > 3 order by age limit 1 offset 1', 'age', :number, 5, 'age' do
+      [1, 2, 3, 4, 5].each{|i| Person.make! :age => i}
+    end
+
+    it_processes_single_select_column 'city_name', 'city_name', :string, 'Buenos Aires', 'city_name' do
+      Person.make! :city => City.make!(:name => 'Buenos Aires')
+    end
+
+    it_processes_single_select_column 'city_country_name', 'city_country_name', :string, 'Argentina', 'city_country_name' do
+      Person.make! :city => City.make!(:country => Country.make!(:name => 'Argentina'))
+    end
+
+    it_processes_single_select_column 'city_country_name group by city_country_name', 'city_country_name', :string, 'Argentina', 'city_country_name' do
+      Person.make! :city => City.make!(:country => Country.make!(:name => 'Argentina'))
+    end
+
+    it "processes with conditions as string" do
+      Person.make! :age => 1
+      Person.make! :age => 2
+      Person.make! :age => 3
+
+      table = exec 'select age', :conditions => 'age = 2'
+
+      expect(table.rows.length).to eq(1)
+      expect(table.rows[0].c.length).to eq(1)
+      expect(table.rows[0].c[0].v).to eq(2)
+    end
+
+    it "processes with conditions as string and another filter" do
+      Person.make! :age => 1
+      Person.make! :age => 2
+      Person.make! :age => 3
+
+      table = exec 'select age where age > 1', :conditions => 'age < 3'
+
+      expect(table.rows.length).to eq(1)
+      expect(table.rows[0].c.length).to eq(1)
+      expect(table.rows[0].c[0].v).to eq(2)
+    end
+
+    it "processes with conditions as array" do
+      Person.make! :age => 1
+      Person.make! :age => 2
+      Person.make! :age => 3
+
+      table = exec 'select age', :conditions => ['age = ?', 2]
+
+      expect(table.rows.length).to eq(1)
+      expect(table.rows[0].c.length).to eq(1)
+      expect(table.rows[0].c[0].v).to eq(2)
+    end
+
+    it "processes with conditions as array and another filter" do
+      Person.make! :age => 1
+      Person.make! :age => 2
+      Person.make! :age => 3
+
+      table = exec 'select age where age > 1', :conditions => ['age < ?', 3]
+
+      expect(table.rows.length).to eq(1)
+      expect(table.rows[0].c.length).to eq(1)
+      expect(table.rows[0].c[0].v).to eq(2)
+    end
+
+    it "processes with conditions as empty array and another filter" do
+      Person.make! :age => 1
+      Person.make! :age => 2
+      Person.make! :age => 3
+
+      table = exec 'select age where age > 2', :conditions => []
+
+      expect(table.rows.length).to eq(1)
+      expect(table.rows[0].c.length).to eq(1)
+      expect(table.rows[0].c[0].v).to eq(3)
+    end
+
+    [['year', 2006], ['month', 5], ['day', 2],
+    ['hour', 3], ['minute', 4], ['second', 9],
+    ['dayOfWeek', 3]].each do |str, val|
+      it_processes_single_select_column "#{str}(created_at)", 'c0', :number, val, "#{str}(created_at)" do
+        Person.make! :created_at => Time.parse('2006-05-02 3:04:09')
       end
-      i += 1
     end
-  end
 
-  it "processes pivot3" do
-    Person.make :name => 'Eng', :birthday => '2000-01-12', :age => 10
-    Person.make :name => 'Eng', :birthday => '2001-02-12', :age => 10
+    #  it_processes_single_select_column "quarter(created_at)", 'c0', :number, 2, 'quarter(created_at)' do
+    #    Person.make! :created_at => Time.parse('2006-05-02 3:04:09')
+    #  end
 
-    table = exec 'select name, sum(age) group by name pivot year(birthday), month(birthday)'
+    it_processes_single_select_column "dateDiff(date '2008-03-13', date '2008-03-10')", 'c0', :number, 3, "dateDiff(date '2008-03-13', date '2008-03-10')"
 
-    table.cols.length.should == 3
+    #  it_processes_single_select_column "now()", 'c0', :datetime, Time.now.utc.strftime("%Y-%m-%d %H:%M:%S"), "now()" do
+    #    Person.make! :created_at => Time.parse('2006-05-02 3:04:09')
+    #  end
 
-    i = 0
-    [['Eng', 10, 10]].each do |values|
-      table.rows[i].c.length.should == 3
-      values.each_with_index do |v, j|
-        table.rows[i].c[j].v.should == v
+    it_processes_single_select_column "toDate('2008-03-13')", 'c0', :date, Time.parse("2008-03-13").to_date, "toDate('2008-03-13')"
+
+    it_processes_single_select_column "toDate(created_at)", 'c0', :date, Time.parse("2008-03-13").to_date, "toDate(created_at)" do
+      Person.make! :created_at => Time.parse('2008-03-13 3:04:09')
+    end
+
+    #  it_processes_single_select_column "toDate(1234567890000)", 'c0', :date, Date.parse('2009-02-13').to_s, "toDate(1234567890000)"
+
+    it_processes_single_select_column "upper(name)", 'c0', :string, 'FOO', "upper(name)" do
+      Person.make! :name => 'foo'
+    end
+
+    it_processes_single_select_column "lower(name)", 'c0', :string, 'foo', "lower(name)" do
+      Person.make! :name => 'FOO'
+    end
+
+    it_processes_single_select_column "concat(age)", 'c0', :string, '20', "concat(age)" do
+      Person.make! :age => 20
+    end
+
+    it_processes_single_select_column "concat(name, 'bar')", 'c0', :string, 'foobar', "concat(name, 'bar')" do
+      Person.make! :name => 'foo'
+    end
+
+    it_processes_single_select_column 'round(1.2)', 'c0', :number, 1, 'round(1.2)', nil, :extensions => true
+
+    it_processes_single_select_column 'floor(1.2)', 'c0', :number, 1, 'floor(1.2)', nil, :extensions => true
+
+    it_processes_single_select_column "name label name 'my name'", 'name', :string, 'foo', "my name" do
+      Person.make! :name => 'foo'
+    end
+
+    it_processes_single_select_column "1 + 2 label 1 + 2 'my name'", 'c0', :number, 3, "my name"
+
+    it_processes_single_select_column "sum(age) label sum(age) 'my name'", 'c0', :number, 2, "my name" do
+      Person.make! :age => 2
+    end
+
+    it_processes_single_select_column "1 options no_values", 'c0', :number, nil, "1"
+
+    it_processes_single_select_column '1 where foo_bars_id != 0', 'c0', :number, 1, '1', nil, :model => Foo do
+      foo = Foo.create!
+      FooBar.create! :foo_id => foo.id
+    end
+
+    it "processes pivot" do
+      Person.make! :name => 'Eng', :birthday => '2000-01-12', :age => 1000
+      Person.make! :name => 'Eng', :birthday => '2000-01-12', :age => 500
+      Person.make! :name => 'Eng', :birthday => '2000-01-13', :age => 600
+      Person.make! :name => 'Sales', :birthday => '2000-01-12', :age => 400
+      Person.make! :name => 'Sales', :birthday => '2000-01-12', :age => 350
+      Person.make! :name => 'Marketing', :birthday => '2000-01-13', :age => 800
+
+      table = exec 'select name, sum(age) group by name pivot birthday order by name'
+
+      expect(table.cols.length).to eq(3)
+
+      i = 0
+      [['c0', :string, 'name'],
+      ['c1', :number, '2000-01-12 sum(age)'],
+      ['c2', :number, '2000-01-13 sum(age)']].each do |id, type, label|
+        expect(table.cols[i].id).to eq(id)
+        expect(table.cols[i].type).to eq(type)
+        expect(table.cols[i].label).to eq(label)
+        i += 1
       end
-      i += 1
-    end
-  end
 
-  it "processes pivot4" do
-    Person.make :name => 'Eng', :birthday => '2000-01-12', :age => 10
-    Person.make :name => 'Sales', :birthday => '2001-02-12', :age => 20
+      expect(table.rows.length).to eq(3)
 
-    table = exec 'select birthday, month(birthday), sum(age) group by month(birthday) pivot name order by name'
-
-    table.cols.length.should == 5
-
-    i = 0
-    [
-      [Time.parse('2000-01-12').to_date, nil, 1, 10, nil],
-      [nil, Time.parse('2001-02-12').to_date, 2, nil, 20],
-    ].each do |values|
-      table.rows[i].c.length.should == 5
-      values.each_with_index do |v, j|
-        table.rows[i].c[j].v.should == v
+      i = 0
+      [['Eng', 1500, 600],
+      ['Marketing', nil, 800],
+      ['Sales', 750, nil]].each do |values|
+        expect(table.rows[i].c.length).to eq(3)
+        values.each_with_index do |v, j|
+          expect(table.rows[i].c[j].v).to eq(v)
+        end
+        i += 1
       end
-      i += 1
-    end
-  end
-
-  it "processes pivot without group by" do
-    Person.make :name => 'Eng', :birthday => '2000-01-12', :age => 1000
-    Person.make :name => 'Eng', :birthday => '2000-01-12', :age => 500
-    Person.make :name => 'Eng', :birthday => '2000-01-13', :age => 600
-    Person.make :name => 'Sales', :birthday => '2000-01-12', :age => 400
-    Person.make :name => 'Sales', :birthday => '2000-01-12', :age => 350
-    Person.make :name => 'Marketing', :birthday => '2000-01-13', :age => 800
-
-    table = exec 'select sum(age) pivot name order by name'
-
-    table.cols.length.should == 3
-
-    i = 0
-    [['c0', :number, 'Eng sum(age)'],
-     ['c1', :number, 'Marketing sum(age)'],
-     ['c2', :number, 'Sales sum(age)']].each do |id, type, label|
-      table.cols[i].id.should == id
-      table.cols[i].type.should == type
-      table.cols[i].label.should == label
-      i += 1
     end
 
-    table.rows.length.should == 1
+    it "processes pivot2" do
+      Person.make! :name => 'Eng', :birthday => '2000-01-12', :age => 1000
+      Person.make! :name => 'Eng', :birthday => '2000-01-12', :age => 500
+      Person.make! :name => 'Eng', :birthday => '2000-01-13', :age => 600
+      Person.make! :name => 'Sales', :birthday => '2000-01-12', :age => 400
+      Person.make! :name => 'Sales', :birthday => '2000-01-12', :age => 350
+      Person.make! :name => 'Marketing', :birthday => '2000-01-13', :age => 800
 
-    i = 0
-    [[2100, 800, 750]].each do |values|
-      table.rows[i].c.length.should == 3
-      values.each_with_index do |v, j|
-        table.rows[i].c[j].v.should == v
+      table = exec 'select sum(age), name group by name pivot birthday order by name'
+
+      expect(table.cols.length).to eq(3)
+
+      i = 0
+      [['c0', :number, '2000-01-12 sum(age)'],
+      ['c1', :number, '2000-01-13 sum(age)'],
+      ['c2', :string, 'name']].each do |id, type, label|
+        expect(table.cols[i].id).to eq(id)
+        expect(table.cols[i].type).to eq(type)
+        expect(table.cols[i].label).to eq(label)
+        i += 1
       end
-      i += 1
-    end
-  end
 
-  it "processes pivot with no results" do
-    Person.make :name => 'Eng', :birthday => '2000-01-12', :age => 10
-    Person.make :name => 'Sales', :birthday => '2001-02-12', :age => 20
+      expect(table.rows.length).to eq(3)
 
-    table = exec 'select birthday, sum(age) where 1 = 2 group by month(birthday) pivot name order by name'
-
-    table.cols.length.should == 2
-
-    i = 0
-    [['birthday', :date, 'birthday'],
-     ['c1', :number, 'sum(age)']].each do |id, type, label|
-      table.cols[i].id.should == id
-      table.cols[i].type.should == type
-      table.cols[i].label.should == label
-      i += 1
-    end
-  end
-
-  it "processes pivot with group by not in select" do
-    Person.make :name => 'Eng', :birthday => '2000-01-12', :age => 10
-    Person.make :name => 'Sales', :birthday => '2001-02-12', :age => 20
-
-    table = exec 'select birthday, sum(age) group by month(birthday) pivot name order by name'
-
-    table.cols.length.should == 4
-
-    i = 0
-    [
-      [Time.parse('2000-01-12').to_date, nil, 10, nil],
-      [nil, Time.parse('2001-02-12').to_date, nil, 20],
-    ].each do |values|
-      table.rows[i].c.length.should == 4
-      values.each_with_index do |v, j|
-        table.rows[i].c[j].v.should == v
+      i = 0
+      [[1500, 600, 'Eng'],
+      [nil, 800, 'Marketing'],
+      [750, nil, 'Sales']].each do |values|
+        expect(table.rows[i].c.length).to eq(3)
+        values.each_with_index do |v, j|
+          expect(table.rows[i].c[j].v).to eq(v)
+        end
+        i += 1
       end
-      i += 1
-    end
-  end
-
-  it "processes pivot with zeros instead of nulls in count" do
-    Person.make :name => 'Eng', :birthday => '2000-01-12', :age => 1000
-    Person.make :name => 'Eng', :birthday => '2000-01-12', :age => 500
-    Person.make :name => 'Eng', :birthday => '2000-01-13', :age => 600
-    Person.make :name => 'Sales', :birthday => '2000-01-12', :age => 400
-    Person.make :name => 'Sales', :birthday => '2000-01-12', :age => 350
-    Person.make :name => 'Marketing', :birthday => '2000-01-13', :age => 800
-
-    table = exec 'select name, count(age) group by name pivot birthday order by name'
-
-    table.cols.length.should == 3
-
-    i = 0
-    [['c0', :string, 'name'],
-     ['c1', :number, '2000-01-12 count(age)'],
-     ['c2', :number, '2000-01-13 count(age)']].each do |id, type, label|
-      table.cols[i].id.should == id
-      table.cols[i].type.should == type
-      table.cols[i].label.should == label
-      i += 1
     end
 
-    table.rows.length.should == 3
+    it "processes pivot3" do
+      Person.make! :name => 'Eng', :birthday => '2000-01-12', :age => 10
+      Person.make! :name => 'Eng', :birthday => '2001-02-12', :age => 10
 
-    i = 0
-    [['Eng', 2, 1],
-     ['Marketing', 0, 1],
-     ['Sales', 2, 0]].each do |values|
-      table.rows[i].c.length.should == 3
-      values.each_with_index do |v, j|
-        table.rows[i].c[j].v.should == v
+      table = exec 'select name, sum(age) group by name pivot year(birthday), month(birthday)'
+
+      expect(table.cols.length).to eq(3)
+
+      i = 0
+      [['Eng', 10, 10]].each do |values|
+        expect(table.rows[i].c.length).to eq(3)
+        values.each_with_index do |v, j|
+          expect(table.rows[i].c[j].v).to eq(v)
+        end
+        i += 1
       end
-      i += 1
-    end
-  end
-
-  # Formatting
-  it_processes_single_select_column 'false format false "%s is falsey"', 'c0', :boolean, false, 'false', 'false is falsey'
-  it_processes_single_select_column '1 format 1 "%.2f"', 'c0', :number, 1, '1', '1.00'
-  it_processes_single_select_column '1.2 format 1.2 "%.2f"', 'c0', :number, 1.2, '1.2', '1.20'
-  it_processes_single_select_column '"hello" format "hello" "%s world"', 'c0', :string, "hello", "'hello'", 'hello world'
-  it_processes_single_select_column 'date "2001-01-02" format date "2001-01-02" "%Y"', 'c0', :date, Time.parse('2001-01-02').to_date, "date '2001-01-02'", '2001'
-
-  it "processes pivot with format" do
-    Person.make :name => 'Eng', :birthday => '2000-01-12', :age => 1000
-    Person.make :name => 'Eng', :birthday => '2000-01-12', :age => 500
-    Person.make :name => 'Eng', :birthday => '2000-01-13', :age => 600
-    Person.make :name => 'Sales', :birthday => '2000-01-12', :age => 400
-    Person.make :name => 'Sales', :birthday => '2000-01-12', :age => 350
-    Person.make :name => 'Marketing', :birthday => '2000-01-13', :age => 800
-
-    table = exec 'select name, sum(age) group by name pivot birthday order by name format name "x %s", sum(age) "%.2f"'
-
-    table.cols.length.should == 3
-
-    i = 0
-    [['c0', :string, 'name'],
-     ['c1', :number, '2000-01-12 sum(age)'],
-     ['c2', :number, '2000-01-13 sum(age)']].each do |id, type, label|
-      table.cols[i].id.should == id
-      table.cols[i].type.should == type
-      table.cols[i].label.should == label
-      i += 1
     end
 
-    table.rows.length.should == 3
+    it "processes pivot4" do
+      Person.make! :name => 'Eng', :birthday => '2000-01-12', :age => 10
+      Person.make! :name => 'Sales', :birthday => '2001-02-12', :age => 20
 
-    i = 0
-    [[['Eng', 'x Eng'], [1500, '1500.00'], [600, '600.00']],
-     [['Marketing', 'x Marketing'], [nil, nil], [800, '800.00']],
-     [['Sales', 'x Sales'], [750, '750.00'], [nil, nil]]].each do |values|
-      table.rows[i].c.length.should == 3
-      values.each_with_index do |v, j|
-        table.rows[i].c[j].v.should == v[0]
-        table.rows[i].c[j].f.should == v[1]
+      table = exec 'select birthday, month(birthday), sum(age) group by month(birthday) pivot name order by name'
+
+      expect(table.cols.length).to eq(5)
+
+      i = 0
+      [
+        [Time.parse('2000-01-12').to_date, nil, 1, 10, nil],
+        [nil, Time.parse('2001-02-12').to_date, 2, nil, 20],
+      ].each do |values|
+        expect(table.rows[i].c.length).to eq(5)
+        values.each_with_index do |v, j|
+          expect(table.rows[i].c[j].v).to eq(v)
+        end
+        i += 1
       end
-      i += 1
-    end
-  end
-
-  it "raises on unknown column" do
-    lambda { exec "select something" }.should raise_exception(Exception, "Unknown column something")
-  end
-
-  context "date formatting" do
-    it "encodes date as json" do
-      executor = Rgviz::Executor.new Person
-      column = Rgviz::Column.new :type => :date
-      value = executor.column_value column, "2012-01-02"
-      value.encode_json.should eq("new Date(2012,0,02)")
     end
 
-    it "encodes datetime as json" do
-      executor = Rgviz::Executor.new Person
-      column = Rgviz::Column.new :type => :datetime
-      value = executor.column_value column, "2012-01-02 10:11:12"
-      value.encode_json.should eq("new Date(2012,0,02,10,11,12)")
+    it "processes pivot without group by" do
+      Person.make! :name => 'Eng', :birthday => '2000-01-12', :age => 1000
+      Person.make! :name => 'Eng', :birthday => '2000-01-12', :age => 500
+      Person.make! :name => 'Eng', :birthday => '2000-01-13', :age => 600
+      Person.make! :name => 'Sales', :birthday => '2000-01-12', :age => 400
+      Person.make! :name => 'Sales', :birthday => '2000-01-12', :age => 350
+      Person.make! :name => 'Marketing', :birthday => '2000-01-13', :age => 800
+
+      table = exec 'select sum(age) pivot name order by name'
+
+      expect(table.cols.length).to eq(3)
+
+      i = 0
+      [['c0', :number, 'Eng sum(age)'],
+      ['c1', :number, 'Marketing sum(age)'],
+      ['c2', :number, 'Sales sum(age)']].each do |id, type, label|
+        expect(table.cols[i].id).to eq(id)
+        expect(table.cols[i].type).to eq(type)
+        expect(table.cols[i].label).to eq(label)
+        i += 1
+      end
+
+      expect(table.rows.length).to eq(1)
+
+      i = 0
+      [[2100, 800, 750]].each do |values|
+        expect(table.rows[i].c.length).to eq(3)
+        values.each_with_index do |v, j|
+          expect(table.rows[i].c[j].v).to eq(v)
+        end
+        i += 1
+      end
+    end
+
+    it "processes pivot with no results" do
+      Person.make! :name => 'Eng', :birthday => '2000-01-12', :age => 10
+      Person.make! :name => 'Sales', :birthday => '2001-02-12', :age => 20
+
+      table = exec 'select birthday, sum(age) where 1 = 2 group by month(birthday) pivot name order by name'
+
+      expect(table.cols.length).to eq(2)
+
+      i = 0
+      [['birthday', :date, 'birthday'],
+      ['c1', :number, 'sum(age)']].each do |id, type, label|
+        expect(table.cols[i].id).to eq(id)
+        expect(table.cols[i].type).to eq(type)
+        expect(table.cols[i].label).to eq(label)
+        i += 1
+      end
+    end
+
+    it "processes pivot with group by not in select" do
+      Person.make! :name => 'Eng', :birthday => '2000-01-12', :age => 10
+      Person.make! :name => 'Sales', :birthday => '2001-02-12', :age => 20
+
+      table = exec 'select birthday, sum(age) group by month(birthday) pivot name order by name'
+
+      expect(table.cols.length).to eq(4)
+
+      i = 0
+      [
+        [Time.parse('2000-01-12').to_date, nil, 10, nil],
+        [nil, Time.parse('2001-02-12').to_date, nil, 20],
+      ].each do |values|
+        expect(table.rows[i].c.length).to eq(4)
+        values.each_with_index do |v, j|
+          expect(table.rows[i].c[j].v).to eq(v)
+        end
+        i += 1
+      end
+    end
+
+    it "processes pivot with zeros instead of nulls in count" do
+      Person.make! :name => 'Eng', :birthday => '2000-01-12', :age => 1000
+      Person.make! :name => 'Eng', :birthday => '2000-01-12', :age => 500
+      Person.make! :name => 'Eng', :birthday => '2000-01-13', :age => 600
+      Person.make! :name => 'Sales', :birthday => '2000-01-12', :age => 400
+      Person.make! :name => 'Sales', :birthday => '2000-01-12', :age => 350
+      Person.make! :name => 'Marketing', :birthday => '2000-01-13', :age => 800
+
+      table = exec 'select name, count(age) group by name pivot birthday order by name'
+
+      expect(table.cols.length).to eq(3)
+
+      i = 0
+      [['c0', :string, 'name'],
+      ['c1', :number, '2000-01-12 count(age)'],
+      ['c2', :number, '2000-01-13 count(age)']].each do |id, type, label|
+        expect(table.cols[i].id).to eq(id)
+        expect(table.cols[i].type).to eq(type)
+        expect(table.cols[i].label).to eq(label)
+        i += 1
+      end
+
+      expect(table.rows.length).to eq(3)
+
+      i = 0
+      [['Eng', 2, 1],
+      ['Marketing', 0, 1],
+      ['Sales', 2, 0]].each do |values|
+        expect(table.rows[i].c.length).to eq(3)
+        values.each_with_index do |v, j|
+          expect(table.rows[i].c[j].v).to eq(v)
+        end
+        i += 1
+      end
+    end
+
+    # Formatting
+    it_processes_single_select_column 'false format false "%s is falsey"', 'c0', :boolean, false, 'false', 'false is falsey'
+    it_processes_single_select_column '1 format 1 "%.2f"', 'c0', :number, 1, '1', '1.00'
+    it_processes_single_select_column '1.2 format 1.2 "%.2f"', 'c0', :number, 1.2, '1.2', '1.20'
+    it_processes_single_select_column '"hello" format "hello" "%s world"', 'c0', :string, "hello", "'hello'", 'hello world'
+    it_processes_single_select_column 'date "2001-01-02" format date "2001-01-02" "%Y"', 'c0', :date, Time.parse('2001-01-02').to_date, "date '2001-01-02'", '2001'
+
+    it "processes pivot with format" do
+      Person.make! :name => 'Eng', :birthday => '2000-01-12', :age => 1000
+      Person.make! :name => 'Eng', :birthday => '2000-01-12', :age => 500
+      Person.make! :name => 'Eng', :birthday => '2000-01-13', :age => 600
+      Person.make! :name => 'Sales', :birthday => '2000-01-12', :age => 400
+      Person.make! :name => 'Sales', :birthday => '2000-01-12', :age => 350
+      Person.make! :name => 'Marketing', :birthday => '2000-01-13', :age => 800
+
+      table = exec 'select name, sum(age) group by name pivot birthday order by name format name "x %s", sum(age) "%.2f"'
+
+      expect(table.cols.length).to eq(3)
+
+      i = 0
+      [['c0', :string, 'name'],
+      ['c1', :number, '2000-01-12 sum(age)'],
+      ['c2', :number, '2000-01-13 sum(age)']].each do |id, type, label|
+        expect(table.cols[i].id).to eq(id)
+        expect(table.cols[i].type).to eq(type)
+        expect(table.cols[i].label).to eq(label)
+        i += 1
+      end
+
+      expect(table.rows.length).to eq(3)
+
+      i = 0
+      [[['Eng', 'x Eng'], [1500, '1500.00'], [600, '600.00']],
+      [['Marketing', 'x Marketing'], [nil, nil], [800, '800.00']],
+      [['Sales', 'x Sales'], [750, '750.00'], [nil, nil]]].each do |values|
+        expect(table.rows[i].c.length).to eq(3)
+        values.each_with_index do |v, j|
+          expect(table.rows[i].c[j].v).to eq(v[0])
+          expect(table.rows[i].c[j].f).to eq(v[1])
+        end
+        i += 1
+      end
+    end
+
+    it "raises on unknown column" do
+      expect { exec "select something" }.to raise_error(Exception, "Unknown column something")
+    end
+
+    context "date formatting" do
+      it "encodes date as json" do
+        executor = Rgviz::Executor.new Person
+        column = Rgviz::Column.new :type => :date
+        value = executor.column_value column, "2012-01-02"
+        expect(value.encode_json).to eq("new Date(2012,0,02)")
+      end
+
+      it "encodes datetime as json" do
+        executor = Rgviz::Executor.new Person
+        column = Rgviz::Column.new :type => :datetime
+        value = executor.column_value column, "2012-01-02 10:11:12"
+        expect(value.encode_json).to eq("new Date(2012,0,02,10,11,12)")
+      end
     end
   end
-end

--- a/spec/rgviz_rails/parser_spec.rb
+++ b/spec/rgviz_rails/parser_spec.rb
@@ -20,7 +20,7 @@ describe RgvizRails::Parser do
 
       it "parses a time string" do
         now = Time.now
-        parser.public_parse_time(now.strftime(format)).to_i.should == now.to_i
+        expect(parser.public_parse_time(now.strftime(format)).to_i).to  eq(now.to_i)
       end
     end
 
@@ -29,7 +29,7 @@ describe RgvizRails::Parser do
         Time.zone = time_zone
         now = Time.now
         parsed = parser.public_parse_time(now.strftime(format))
-        (now.to_i - parsed.to_i).should == Time.zone.utc_offset
+        expect((now.to_i - parsed.to_i)).to eq(Time.zone.utc_offset)
       end
 
       it "parses a time string with the Pacific time zone" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ require "rubygems"
 require "logger"
 require "rails/all"
 require "active_record"
+require 'active_support/all'
 
 ActiveRecord::Base.establish_connection(:adapter => "sqlite3", :database => ":memory:")
 #ActiveRecord::Base.establish_connection(:adapter => "mysql2", :database => "rgviz_rails", :username => "root", :password => "")


### PR DESCRIPTION
This PR replaces the deprecated 'render :text' method with 'render plain' in order to ensure that plain text rendering in our codebase is up-to-date and consistent. 